### PR TITLE
Added new array args 'before_sidebar' and 'after_sidebar'

### DIFF
--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -699,7 +699,7 @@ function dynamic_sidebar( $index = 1 ) {
 		return apply_filters( 'dynamic_sidebar_has_widgets', false, $index );
 	}
 
-	$sidebar                   = $wp_registered_sidebars[$index];
+	$sidebar                   = $wp_registered_sidebars[ $index ];
 	$sidebar['before_sidebar'] = sprintf( $sidebar['before_sidebar'], $sidebar['id'], $sidebar['class'] );
 
 	/**

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -225,22 +225,28 @@ function register_sidebars( $number = 1, $args = array() ) {
  * @param array|string $args {
  *     Optional. Array or string of arguments for the sidebar being registered.
  *
- *     @type string $name          The name or title of the sidebar displayed in the Widgets
- *                                 interface. Default 'Sidebar $instance'.
- *     @type string $id            The unique identifier by which the sidebar will be called.
- *                                 Default 'sidebar-$instance'.
- *     @type string $description   Description of the sidebar, displayed in the Widgets interface.
- *                                 Default empty string.
- *     @type string $class         Extra CSS class to assign to the sidebar in the Widgets interface.
- *                                 Default empty.
- *     @type string $before_widget HTML content to prepend to each widget's HTML output when
- *                                 assigned to this sidebar. Default is an opening list item element.
- *     @type string $after_widget  HTML content to append to each widget's HTML output when
- *                                 assigned to this sidebar. Default is a closing list item element.
- *     @type string $before_title  HTML content to prepend to the sidebar title when displayed.
- *                                 Default is an opening h2 element.
- *     @type string $after_title   HTML content to append to the sidebar title when displayed.
- *                                 Default is a closing h2 element.
+ *     @type string $name           The name or title of the sidebar displayed in the Widgets
+ *                                  interface. Default 'Sidebar $instance'.
+ *     @type string $id             The unique identifier by which the sidebar will be called.
+ *                                  Default 'sidebar-$instance'.
+ *     @type string $description    Description of the sidebar, displayed in the Widgets interface.
+ *                                  Default empty string.
+ *     @type string $class          Extra CSS class to assign to the sidebar in the Widgets interface.
+ *                                  Default empty.
+ *     @type string $before_widget  HTML content to prepend to each widget's HTML output when
+ *                                  assigned to this sidebar. Default is an opening list item element.
+ *     @type string $after_widget   HTML content to append to each widget's HTML output when
+ *                                  assigned to this sidebar. Default is a closing list item element.
+ *     @type string $before_title   HTML content to prepend to the sidebar title when displayed.
+ *                                  Default is an opening h2 element.
+ *     @type string $after_title    HTML content to append to the sidebar title when displayed.
+ *                                  Default is a closing h2 element.
+ *     @type string $before_sidebar HTML content to prepend to the sidebar.
+ *                                  Outputs after the dynamic_sidebar_before action.
+ *                                  Default is an empty string.
+ *     @type string $after_sidebar  HTML content to append to the sidebar when displayed.
+ *                                  Outputs before the dynamic_sidebar_after action.
+ *                                  Default is an empty string.
  * }
  * @return string Sidebar ID added to $wp_registered_sidebars global.
  */
@@ -253,14 +259,16 @@ function register_sidebar( $args = array() ) {
 
 	$defaults = array(
 		/* translators: %d: Sidebar number. */
-		'name'          => sprintf( __( 'Sidebar %d' ), $i ),
-		'id'            => "sidebar-$i",
-		'description'   => '',
-		'class'         => '',
-		'before_widget' => '<li id="%1$s" class="widget %2$s">',
-		'after_widget'  => "</li>\n",
-		'before_title'  => '<h2 class="widgettitle">',
-		'after_title'   => "</h2>\n",
+		'name'           => sprintf( __( 'Sidebar %d' ), $i ),
+		'id'             => "sidebar-$i",
+		'description'    => '',
+		'class'          => '',
+		'before_widget'  => '<li id="%1$s" class="widget %2$s">',
+		'after_widget'   => "</li>\n",
+		'before_title'   => '<h2 class="widgettitle">',
+		'after_title'    => "</h2>\n",
+		'before_sidebar' => '',
+		'after_sidebar'  => '',
 	);
 
 	/**
@@ -691,6 +699,9 @@ function dynamic_sidebar( $index = 1 ) {
 		return apply_filters( 'dynamic_sidebar_has_widgets', false, $index );
 	}
 
+	$sidebar                   = $wp_registered_sidebars[$index];
+	$sidebar['before_sidebar'] = sprintf( $sidebar['before_sidebar'], $sidebar['id'], $sidebar['class'] );
+
 	/**
 	 * Fires before widgets are rendered in a dynamic sidebar.
 	 *
@@ -704,7 +715,10 @@ function dynamic_sidebar( $index = 1 ) {
 	 *                                Default true.
 	 */
 	do_action( 'dynamic_sidebar_before', $index, true );
-	$sidebar = $wp_registered_sidebars[ $index ];
+
+	if ( ! empty( $sidebar['before_sidebar'] ) ) {
+		echo $sidebar['before_sidebar'];
+	}
 
 	$did_one = false;
 	foreach ( (array) $sidebars_widgets[ $index ] as $id ) {
@@ -805,6 +819,10 @@ function dynamic_sidebar( $index = 1 ) {
 			call_user_func_array( $callback, $params );
 			$did_one = true;
 		}
+	}
+
+	if ( ! empty( $sidebar['after_sidebar'] ) ) {
+		echo $sidebar['after_sidebar'];
 	}
 
 	/**

--- a/tests/phpunit/tests/widgets.php
+++ b/tests/phpunit/tests/widgets.php
@@ -267,9 +267,9 @@ class Tests_Widgets extends WP_UnitTestCase {
 		$this->assertContains( '</div> <!-- .before-sidebar -->', $wp_registered_sidebars[ $sidebar_id ]['after_sidebar'] );
 
 		// Adding widget to the test-sidebar.
-		$sidebars_widgets = get_option( 'sidebars_widgets' );
-		$sidebars_widgets[ $sidebar_id ][] = 'test-1' ;
-		update_option('sidebars_widgets', $sidebars_widgets);
+		$sidebars_widgets                  = get_option( 'sidebars_widgets' );
+		$sidebars_widgets[ $sidebar_id ][] = 'test-1';
+		update_option( 'sidebars_widgets', $sidebars_widgets );
 
 		ob_start();
 		dynamic_sidebar( $sidebar_id );
@@ -298,9 +298,9 @@ class Tests_Widgets extends WP_UnitTestCase {
 		$this->assertContains( '', $wp_registered_sidebars[ $sidebar_id ]['after_sidebar'] );
 
 		// Adding widget to the test-sidebar.
-		$sidebars_widgets = get_option( 'sidebars_widgets' );
-		$sidebars_widgets[ $sidebar_id ][] = 'test-1' ;
-		update_option('sidebars_widgets', $sidebars_widgets);
+		$sidebars_widgets                  = get_option( 'sidebars_widgets' );
+		$sidebars_widgets[ $sidebar_id ][] = 'test-1';
+		update_option( 'sidebars_widgets', $sidebars_widgets );
 
 		ob_start();
 		dynamic_sidebar( $sidebar_id );

--- a/tests/phpunit/tests/widgets.php
+++ b/tests/phpunit/tests/widgets.php
@@ -247,6 +247,71 @@ class Tests_Widgets extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @group sidebar
+	 */
+	function test_register_sidebar_with_after_and_before_sidebar() {
+		global $wp_registered_sidebars;
+
+		$sidebar_id = 'test-sidebar';
+		register_sidebar(
+			array(
+				'id'             => $sidebar_id,
+				'before_sidebar' => '<div id="%1$s" class="before-sidebar %2$s">',
+				'after_sidebar'  => '</div> <!-- .before-sidebar -->',
+				'class'          => 'test-sidebar',
+			)
+		);
+
+		$this->assertArrayHasKey( $sidebar_id, $wp_registered_sidebars );
+		$this->assertContains( '<div id="%1$s" class="before-sidebar %2$s">', $wp_registered_sidebars[ $sidebar_id ]['before_sidebar'] );
+		$this->assertContains( '</div> <!-- .before-sidebar -->', $wp_registered_sidebars[ $sidebar_id ]['after_sidebar'] );
+
+		// Adding widget to the test-sidebar.
+		$sidebars_widgets = get_option( 'sidebars_widgets' );
+		$sidebars_widgets[ $sidebar_id ][] = 'test-1' ;
+		update_option('sidebars_widgets', $sidebars_widgets);
+
+		ob_start();
+		dynamic_sidebar( $sidebar_id );
+		$output = ob_get_clean();
+
+		$this->assertContains( '<div id="test-sidebar" class="before-sidebar test-sidebar">', $output );
+		$this->assertContains( '</div> <!-- .before-sidebar -->', $output );
+
+	}
+
+	/**
+	 * @group sidebar
+	 */
+	function test_register_sidebar_without_after_and_before_sidebar() {
+		global $wp_registered_sidebars;
+
+		$sidebar_id = 'test-sidebar-2';
+		register_sidebar(
+			array(
+				'id' => $sidebar_id,
+			)
+		);
+
+		$this->assertArrayHasKey( $sidebar_id, $wp_registered_sidebars );
+		$this->assertContains( '', $wp_registered_sidebars[ $sidebar_id ]['before_sidebar'] );
+		$this->assertContains( '', $wp_registered_sidebars[ $sidebar_id ]['after_sidebar'] );
+
+		// Adding widget to the test-sidebar.
+		$sidebars_widgets = get_option( 'sidebars_widgets' );
+		$sidebars_widgets[ $sidebar_id ][] = 'test-1' ;
+		update_option('sidebars_widgets', $sidebars_widgets);
+
+		ob_start();
+		dynamic_sidebar( $sidebar_id );
+		$output = ob_get_clean();
+
+		$this->assertNotContains( '<div id="test-sidebar" class="before-sidebar test-sidebar">', $output );
+		$this->assertNotContains( '</div> <!-- .before-sidebar -->', $output );
+
+	}
+
+	/**
 	 * Utility hook callback used to store a sidebar ID mid-function.
 	 */
 	function retrieve_sidebar_id( $index, $valid_sidebar ) {

--- a/tests/phpunit/tests/widgets.php
+++ b/tests/phpunit/tests/widgets.php
@@ -249,7 +249,7 @@ class Tests_Widgets extends WP_UnitTestCase {
 	/**
 	 * @group sidebar
 	 */
-	function test_register_sidebar_with_after_and_before_sidebar() {
+	public function test_register_sidebar_with_after_and_before_sidebar() {
 		global $wp_registered_sidebars;
 
 		$sidebar_id = 'test-sidebar';
@@ -266,24 +266,12 @@ class Tests_Widgets extends WP_UnitTestCase {
 		$this->assertContains( '<div id="%1$s" class="before-sidebar %2$s">', $wp_registered_sidebars[ $sidebar_id ]['before_sidebar'] );
 		$this->assertContains( '</div> <!-- .before-sidebar -->', $wp_registered_sidebars[ $sidebar_id ]['after_sidebar'] );
 
-		// Adding widget to the test-sidebar.
-		$sidebars_widgets                  = get_option( 'sidebars_widgets' );
-		$sidebars_widgets[ $sidebar_id ][] = 'test-1';
-		update_option( 'sidebars_widgets', $sidebars_widgets );
-
-		ob_start();
-		dynamic_sidebar( $sidebar_id );
-		$output = ob_get_clean();
-
-		$this->assertContains( '<div id="test-sidebar" class="before-sidebar test-sidebar">', $output );
-		$this->assertContains( '</div> <!-- .before-sidebar -->', $output );
-
 	}
 
 	/**
 	 * @group sidebar
 	 */
-	function test_register_sidebar_without_after_and_before_sidebar() {
+	public function test_register_sidebar_without_after_and_before_sidebar() {
 		global $wp_registered_sidebars;
 
 		$sidebar_id = 'test-sidebar-2';
@@ -296,18 +284,6 @@ class Tests_Widgets extends WP_UnitTestCase {
 		$this->assertArrayHasKey( $sidebar_id, $wp_registered_sidebars );
 		$this->assertContains( '', $wp_registered_sidebars[ $sidebar_id ]['before_sidebar'] );
 		$this->assertContains( '', $wp_registered_sidebars[ $sidebar_id ]['after_sidebar'] );
-
-		// Adding widget to the test-sidebar.
-		$sidebars_widgets                  = get_option( 'sidebars_widgets' );
-		$sidebars_widgets[ $sidebar_id ][] = 'test-1';
-		update_option( 'sidebars_widgets', $sidebars_widgets );
-
-		ob_start();
-		dynamic_sidebar( $sidebar_id );
-		$output = ob_get_clean();
-
-		$this->assertNotContains( '<div id="test-sidebar" class="before-sidebar test-sidebar">', $output );
-		$this->assertNotContains( '</div> <!-- .before-sidebar -->', $output );
 
 	}
 

--- a/tests/phpunit/tests/widgets.php
+++ b/tests/phpunit/tests/widgets.php
@@ -282,8 +282,8 @@ class Tests_Widgets extends WP_UnitTestCase {
 		);
 
 		$this->assertArrayHasKey( $sidebar_id, $wp_registered_sidebars );
-		$this->assertContains( '', $wp_registered_sidebars[ $sidebar_id ]['before_sidebar'] );
-		$this->assertContains( '', $wp_registered_sidebars[ $sidebar_id ]['after_sidebar'] );
+		$this->assertEmpty( $wp_registered_sidebars[ $sidebar_id ]['before_sidebar'] );
+		$this->assertEmpty( $wp_registered_sidebars[ $sidebar_id ]['after_sidebar'] );
 
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Added unit test cases and fixed alignment issues from the previous patch.
Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
